### PR TITLE
Upstream debian patches and a fix for *.so symlink creation

### DIFF
--- a/cc_db.c
+++ b/cc_db.c
@@ -199,7 +199,7 @@ int pam_cc_db_get(void *_db, const char *keyname, size_t keylength,
 		return (rc == DB_NOTFOUND) ? PAM_AUTHINFO_UNAVAIL : PAM_SERVICE_ERR;
 	}
 
-	if (val.size < *size) {
+	if (val.size > *size) {
 		return PAM_BUF_ERR;
 	}
 

--- a/cc_pam.c
+++ b/cc_pam.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <syslog.h>
+#include <pwd.h>
 
 #include "cc_private.h"
 
@@ -44,6 +45,41 @@ PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh,
 PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh,
 				int flags, int argc, const char **argv);
 #endif
+
+
+/*
+ * Given the PAM arguments and the user we're authenticating, see if we should
+ * ignore that user because they're root or have a low-numbered UID and we
+ * were configured to ignore such users.  Returns true if we should ignore
+ * them, false otherwise.
+ */
+static int
+_pamcc_should_ignore(const char *username, uid_t minimum_uid)
+{
+	struct passwd pwd;
+	struct passwd *pwdr;
+	char buf[1024];
+	int ret;
+
+	if (minimum_uid > 0) {
+		ret = getpwnam_r(username, &pwd, buf, sizeof(buf), &pwdr);
+		if (ret) {
+			syslog(LOG_DEBUG, "failed to get password file entry");
+			return ret;
+		}
+		if (!pwdr) {
+			syslog(LOG_DEBUG, "no password file entry found");
+			return 1;
+		}
+		if (pwdr->pw_uid <  minimum_uid) {
+			syslog(LOG_DEBUG, "ignoring low-UID user (%u < %u)",
+				pwdr->pw_uid, minimum_uid);
+			return 1;
+		}
+	}
+	return 0;
+}
+
 
 static int _pam_sm_interact(pam_handle_t *pamh,
 			    int flags,
@@ -291,7 +327,9 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
 	unsigned int sm_flags = 0, sm_action = 0;
 	const char *ccredsfile = NULL;
 	const char *action = NULL;
+	const char *name = NULL;
 	int (*selector)(pam_handle_t *, int, unsigned int, const char *);
+	uid_t minimum_uid = 0;
 
 	for (i = 0; i < argc; i++) {
 		if (strcmp(argv[i], "use_first_pass") == 0)
@@ -300,6 +338,8 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
 			sm_flags |= SM_FLAGS_TRY_FIRST_PASS;
 		else if (strcmp(argv[i], "service_specific") == 0)
 			sm_flags |= SM_FLAGS_SERVICE_SPECIFIC;
+		else if (strncmp(argv[i], "minimum_uid=", sizeof("minimum_uid=") - 1) == 0)
+			minimum_uid = atoi(argv[i] + sizeof("minimum_uid=") - 1);
 		else if (strncmp(argv[i], "ccredsfile=", sizeof("ccredsfile=") - 1) == 0)
 			ccredsfile = argv[i] + sizeof("ccredsfile=") - 1;
 		else if (strncmp(argv[i], "action=", sizeof("action=") - 1) == 0)
@@ -320,6 +360,16 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
 	} else if (_pam_sm_parse_action(action, &sm_action) != 0) {
 		syslog(LOG_ERR, "pam_ccreds: invalid action \"%s\"", action);
 	}
+
+	rc = pam_get_user(pamh, &name, NULL);
+	if (rc != PAM_SUCCESS || name == NULL) {
+		if (rc == PAM_CONV_AGAIN)
+			return PAM_INCOMPLETE;
+		else
+			return PAM_SERVICE_ERR;
+	}
+	if (_pamcc_should_ignore(name, minimum_uid))
+		return PAM_USER_UNKNOWN;
 
 	switch (sm_action) {
 	case SM_ACTION_VALIDATE_CCREDS:

--- a/configure.in
+++ b/configure.in
@@ -35,7 +35,8 @@ hpux*) pam_ccreds_so_LD="/bin/ld"
   TARGET_OS="HPUX" ;;
 solaris*) pam_ccreds_so_LD="/usr/ccs/bin/ld"
   pam_ccreds_so_LDFLAGS="-B dynamic -M \$(srcdir)/exports.solaris -G -B group -lc" ;;
-linux*) pam_ccreds_so_LDFLAGS="-shared -Wl,-Bdynamic -Wl,--version-script,\$(srcdir)/exports.linux" ;;
+linux*) pam_ccreds_so_LDFLAGS="-shared -Wl,-Bdynamic -Wl,--version-script,\$(srcdir)/exports.linux"
+  TARGET_OS="LINUX" ;;
 *) pam_ccreds_so_LDFLAGS="-shared" ;;
 esac
 
@@ -43,7 +44,7 @@ AC_SUBST(pam_ccreds_so_LD)
 AC_SUBST(pam_ccreds_so_LDFLAGS)
 
 AM_CONDITIONAL(USE_NATIVE_LINKER, test -n "$pam_ccreds_so_LD")
-AM_CONDITIONAL(EXTENSION_SO, test "$target_os" = "linux" -o "$target_os" = "linux-gnu")
+AM_CONDITIONAL(EXTENSION_SO, test "$TARGET_OS" = "LINUX")
 AM_CONDITIONAL(EXTENSION_1, test "$TARGET_OS" = "HPUX")
 
 if test -z "$use_gcrypt"; then


### PR DESCRIPTION
This PR aims to upstream the patches from Debians libpam-ccreds (https://packages.debian.org/stretch/libpam-ccreds) source archive.
Furthermore I've added a fix for the EXTENSION_SO conditional which decides if the *.so is a symlink or a file.